### PR TITLE
using the exec command in a swatch config file causes zombie processes to be left

### DIFF
--- a/lib/Swatchdog/Actions.pm
+++ b/lib/Swatchdog/Actions.pm
@@ -96,7 +96,7 @@ sub exec_command {
 
  EXECFORK: {
     if ($exec_pid = fork) {
-      waitpid(-1, WNOHANG);
+      waitpid($exec_pid, 0);
       return 0;
     } elsif (defined $exec_pid) {
       exec($command);


### PR DESCRIPTION
This is the proposed fix from https://sourceforge.net/p/swatch/bugs/36/

It was reported at https://bugzilla.redhat.com/show_bug.cgi?id=1621238, and Fedora is now carrying this change.