### PR TITLE
improve and clarify exec functionality

### DIFF
--- a/swatchdog
+++ b/swatchdog
@@ -653,17 +653,19 @@ sub convert_command {
   my $varname = shift;
   my $command = shift;
   my @new_cmd = ();
+  my $i = my $n = my $m;
 
-  $command =~ s/\$[0*]/\$$varname/g if $awk_field_syntax;
+  $command =~ s/(?<!\\)\$[0*]/\$$varname/g;
 
-  foreach my $i (split(/\s+/, $command)) {
-    if ($awk_field_syntax and $i =~ /\$([0-9]+)/) {
-      my $n = substr($i, 1);
-      $n--;
-      push(@new_cmd, "\$$varname\[$n\]");
-    } else {
-      push(@new_cmd, $i);
+  foreach $i (split(/\s+/, $command)) {
+    if ($awk_field_syntax) {
+       while ($i =~ /(?<!\\)\$([1-9]+)/) {
+          $n = $1;
+          $m = $n - 1;
+          $i =~ s/\$$n/\$$varname\[$m\]/;
+       }
     }
+    push(@new_cmd, $i);
   }
 
   return join(' ', @new_cmd);
@@ -737,7 +739,7 @@ sub make_watchfor_block {
   }
   
   if ($do_quit) {
-    $code .= "      exit;\n";
+    $code .= "      &goodbye;\n";
   } elsif (not $do_continue) {
     $code .= "      next;\n";
   }
@@ -1060,7 +1062,7 @@ to perform when each pattern is found.
 
 Use this option only if you want to overide regular expression backreferencing
 in favor of B<awk(1)> style field referencing. Included for backward 
-compatability.
+compatibility.
 
 =item B<--config-file|-c> I<filename>
 
@@ -1210,9 +1212,17 @@ Echo the matched line, and send a bell I<N> times (default = 1).
 =item B<exec command>
 
 Execute I<command>. The I<command> may contain variables which are 
-substituted with fields from the matched line. A I<$N> will be replaced
-by the I<Nth> field in the line. A I<$0> or I<$*> will be replaced by the
-entire line.
+substituted with fields from the matched line. If the B<--awk-field-syntax>
+command-line option has been specified, then each I<$N> will be replaced
+by the I<Nth> field in the line. If the option has not been specified,
+then each I<$N> will refer to a backreference in the regular expression
+used to match the line.
+
+A I<$0> or I<$*> will always be replaced by the entire line, unless they
+have been escaped, regardless of the B<--awk-field-syntax> option.
+
+An escaped I<$N>, I<$0> or I<$*> may have unwanted effects since the value
+will be determined by the shell used to execute the command.
 
 =item B<mail [addresses=address:address:...][,subject=your_text_here]>
 


### PR DESCRIPTION
This was reported against swatch here: https://bugzilla.redhat.com/show_bug.cgi?id=1622187

1) The man page (perlpod) 'exec' section is misleading, and slightly incorrect.
2) The man page 'exec' section says that '$N' variables will be substituted. In fact only the first occurrence is substituted, and if other characters are present (e.g. 'abc$2') then it is not substituted at all.
3) Using the 'quit' action takes too long. In tests it took around 3 minutes for swatch to actually quit.

Steps to Reproduce:
1. Install swatchdog and enter 'cd /tmp'.
2. Create the 'swatchdog.conf' file and enter
     watchfor /something(\d*)/
        exec echo $1$1
        quit
3. Run 'swatchdog --config-file=/tmp/swatchdog.conf --script-dir=. --awk-field-syntax'
4. From another terminal, run 'logger something32'
5. Stop swatchdog (or wait for it to timeout)
6. Modify the config file to use 'exec echo :$1 $1:'
7. Run swatchdog again
8. From another terminal, run 'logger something64'
9. Stop swatchdog
10. Modify the config file to use 'exec echo :$0 $*:'
11. Run swatchdog again
12. From another terminal, run 'logger something82'

Actual results:

(From step 4) output shown is 'Aug' (correct since the first part of the log file line begins with the date/time, but wrong in that the '$1' should appear twice. Adding '--dump-script' to the command-line shows that only one '$1' is substituted. Without the awk-field-syntax option, the correct output is shown.

(From step 5) The 'quit' should execute immediately. It does not because it is actually waiting on the 'tail' command pipe used for input. The wait does eventually time out, not sure what causes that though (tail, perl, exit?)

(From step 8) output shown is 'something64 Aug'. Because of the first colon (:), the $1 is not substituted correctly - it ends up displaying the last token of the log line ('something64'). The second $1 is again substituted correctly, but where have the colons gone? Without the awk-field-syntax, the correct output is shown.

(From step 12) The output is correct. However, if the '--awk-field-option' is removed, an error is shown indicating that '$* is no longer supported'. The output also shows ':./.swatchdog_script.30491 :'. The '$0' is being interpreted as the actual swatchdog script being run.

Expected results:

(From step 4) output should be 'AugAug' when awk-field-option used, and '3232' when it isn't.

(From step 5) The 'quit' should cause swatchdog to immediately exit cleanly.

(From step 8) output should be ':Aug Aug:' when awk field option used, and ':64 64:' when it isn't used.

(From step 12) With the awk fields option, the output should show the whole log line twice, separated by a space and beginning and ending with a colon. Without the awk fields option the output should be exactly the same.


Additional info:

The man page implies that with 'exec' $N variables can be used, but does not specify that their meaning is different depending on whether the '--awk-fields-syntax' option is used or not.

It also implies that '$0' and '$*' will be substituted in all cases. This only happens when the awk fields option is used. However, since without the option these variables end up being interpreted by the shell, we will get the $0 interpreted as the swatchdog script name and $* as nothing (since no parameters are passed to the script). It is probably better, more user friendly, if $0 and $* are substituted in all cases (regardless of the awk fields option).

There is no accounting taken for the fact that a variable may be escaped. Entering '\$0' for example, should not be interpreted (regardless of any options).

Swatchdog currently calls 'exit' when the 'quit' action is seen. But this waits on the tail command to finish. It is better to call the 'goodbye' function already written into the script, and used to handle signals. This will then kill the tail pid, close any pipes and then exit. It happens immediately.

This PR resolves all the above problems, and rewrites most of the 'exec' part of the man page. In addition, all the variables are substituted - provided they are not escaped. Currently, as shown in test step 4 above, only the first variable is substituted. Any others are ignored (so never shown in the output).

It also fixes one typo in the man page.