### PR TITLE
improved handling of @ signs

### DIFF
--- a/swatchdog
+++ b/swatchdog
@@ -574,14 +574,17 @@ sub action_def_to_subroutine_call {
 		 "write" => { 'sub_name' => "&Swatchdog::Actions::write_message", 'def_arg' => 'USERS' },
 		};
 
+  my $opt;
   my %options;
   my $have_opts = 0;
 
   foreach my $v (split(/,/, $optstr)) {
     if ($v =~ /(\w+)\s*=\s*"?(\S+[^"]*)/) {
-      $options{uc $1} = $2;
+      $opt = uc($1);
+      $options{$opt} = $2;
+      $options{$opt} =~ s/@/\\@/g if ($key eq 'mail');
     } else {
-      my $opt = $v;
+      $opt = $v;
       $opt =~ s/@/\\@/g;
       $opt =~ s/^\s+//o;
       $opt =~ s/^\s+$//o;


### PR DESCRIPTION
This was reported against swatch here: https://bugzilla.redhat.com/show_bug.cgi?id=1646480

The swatchdog man page for the mail command shows the syntax as:
mail [addresses=address:address:...][,subject=your_text_here]

However, if the email address contains an '@' sign, then swatchdog fails to start and gives an error. (A similar error will also occur if the 'subject' contains an '@' sign.)

Steps to Reproduce:
1. As root create the ~/.swatchdogrc file:
   watchfor /error/
   mail addresses=abc@example.com
2. Run: swatchdog -c $HOME/.swatchdogrc -t /var/log/messages
3. Modify the .swatchdogrc file, and remove just the 'addresses=' part.
   So the line is now 'mail abc@example.com'
4) Rerun the swatchdog command. It will work this time.
   This is despite not following the man page 'mail' command syntax. However,
   further down the man page shows a use of 'mail' which itself does not include
   'addresses='. (mail=sysad-pager@somehost.somedomain,when=1-6:8-17)

Actual results:
Swatchdog stops, showing the following error message:

Global symbol "@example" requires explicit package name at /root/.swatchdog_script.30106 line 97.
Execution of /root/.swatchdog_script.30106 aborted due to compilation errors.

Expected results:
No error should show when starting swatchdog.

Additional info:

The problem is that the 'addresses=' and 'subject=' parts do not cater for '@' signs in them. When 'addresses=' is left out, then swatchdog does handle them because it goes through a different bit of code.

This PR corrects this. It is only a few lines long.
It has been tested with one and multiple addresses, and the subject line, with an '@' in it has been tested too.